### PR TITLE
Feature/passwordless

### DIFF
--- a/Configurable Self Registration LWC/Custom Registration/force-app/main/default/classes/SiteLoginController.cls
+++ b/Configurable Self Registration LWC/Custom Registration/force-app/main/default/classes/SiteLoginController.cls
@@ -55,10 +55,10 @@ public with sharing class SiteLoginController {
                 //If we are running in a Test, check the test user and throw a custom exception to mimic failed logins.
                 if(Test.isRunningTest()) {
                     switch on username {
-                        when SiteLoginControllerTest.USERNAME_GENERIC_FAIL {
-                            throw new CustomLoginException('Unknown error.'); 
+                        when 'testusergenericfail@mail.com' { //SiteLoginControllerTest.USERNAME_GENERIC_FAIL
+                                                        throw new CustomLoginException('Unknown error.'); 
                         }
-                        when SiteLoginControllerTest.USERNAME_SUCCESSFUL {
+                        when 'testusersuccessful@mail.com'{//SiteLoginControllerTest.USERNAME_SUCCESSFUL 
                             //Don't throw an exception.
                         }
                         when else {

--- a/Configurable Self Registration LWC/Custom Registration/force-app/main/default/classes/SiteRegistrationController.cls
+++ b/Configurable Self Registration LWC/Custom Registration/force-app/main/default/classes/SiteRegistrationController.cls
@@ -470,8 +470,8 @@ public with sharing class SiteRegistrationController {
                     when 'INTEGER' {
                         formInputs.put(key, Integer.valueOf(SiteUtilities.convertToString(formInputs.get(key))));
                     }
-                    when else {
-                        formInputs.put(key, SiteUtilities.convertToString(formInputs.get(key)));
+                    when else { //just logs taht we didn't handle this?
+                        SiteUtilities.createLogEntry(SiteUtilities.convertToBoolean(configurationOptions.get('loggingEnabled')), 'Unhandled datatype: '+dataType+'. this has been left alone', 'Debug', SiteUtilities.SELF_REG_COMPONENT_NAME);        
                     }
                 }
             }    


### PR DESCRIPTION
changed code to no longer use enums in the switch (old habits die hard) and referenced where they are set for future reminders
in the datatype switch, don't handle anything we didn't specifically have a plan for, and just allow it to stay as is, logging that the code ignored it effectively.